### PR TITLE
Add EasyDaddy extension MVP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "easydaddy",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite --watch",
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.0.258",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "pdfjs-dist": "^3.9.179",
+    "idb-keyval": "^6.2.1"
+  }
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "EasyDaddy",
+  "version": "0.1",
+  "description": "Intelligently autofill web forms using ChatGPT",
+  "permissions": ["storage", "scripting"],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/public/popup.html
+++ b/public/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>EasyDaddy</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,63 @@
+const OPENAI_MODEL = 'gpt-4o-mini';
+const OPENAI_KEY = process.env.OPENAI_API_KEY;
+
+async function chat(messages: any[]) {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${OPENAI_KEY}`,
+    },
+    body: JSON.stringify({
+      model: OPENAI_MODEL,
+      messages,
+      temperature: 0.2,
+    }),
+  });
+  const json = await res.json();
+  return json.choices[0].message.content;
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'extract_profile') {
+    (async () => {
+      const prompt = [
+        {
+          role: 'system',
+          content:
+            'You are FormDataExtractor.\nReturn JSON only with the schema provided.',
+        },
+        { role: 'user', content: `RAW_TEXT:\n${msg.text}` },
+      ];
+      const out = await chat(prompt);
+      try {
+        sendResponse(JSON.parse(out));
+      } catch {
+        sendResponse({});
+      }
+    })();
+    return true;
+  }
+  if (msg.type === 'autofill') {
+    (async () => {
+      const prompt = [
+        { role: 'system', content: 'You are FormAutoFiller v1.' },
+        {
+          role: 'user',
+          content: `Given PAGE_CONTEXT and USER_PROFILE return JSON where each key is a CSS selector found in PAGE_CONTEXT.fields and each value is the string we should type. Think step-by-step but output ONLY JSON.\n===\nPAGE_CONTEXT:\n${JSON.stringify(
+            msg.context,
+            null,
+            2
+          )}\n===\nUSER_PROFILE:\n${JSON.stringify(msg.profile, null, 2)}`,
+        },
+      ];
+      const out = await chat(prompt);
+      try {
+        sendResponse(JSON.parse(out));
+      } catch {
+        sendResponse({});
+      }
+    })();
+    return true;
+  }
+});

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,0 +1,59 @@
+interface FieldInfo {
+  selector: string;
+  label: string;
+}
+
+function getSelector(el: Element): string {
+  if (el.id) return `#${el.id}`;
+  const name = (el as HTMLInputElement).name;
+  if (name) return `${el.tagName.toLowerCase()}[name="${name}"]`;
+  return '';
+}
+
+function scanFields(): FieldInfo[] {
+  const els: Element[] = Array.from(
+    document.querySelectorAll('input,textarea,[contenteditable]')
+  );
+  const fields: FieldInfo[] = [];
+  for (const el of els) {
+    const selector = getSelector(el);
+    if (!selector) continue;
+    const labelEl = document.querySelector(`label[for="${(el as any).id}"]`);
+    const label = labelEl ? labelEl.textContent?.trim() || '' : el.getAttribute('placeholder') || '';
+    fields.push({ selector, label });
+  }
+  return fields;
+}
+
+async function fillForm(map: Record<string, string>) {
+  for (const [selector, value] of Object.entries(map)) {
+    const el = document.querySelector(selector) as HTMLInputElement | HTMLTextAreaElement | null;
+    if (el) {
+      (el as any).value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      const prev = (el as HTMLElement).style.outline;
+      (el as HTMLElement).style.outline = '2px solid #f4e7a1';
+      setTimeout(() => {
+        (el as HTMLElement).style.outline = prev;
+      }, 1000);
+    }
+  }
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'start_fill') {
+    (async () => {
+      const context = {
+        url: location.href,
+        title: document.title,
+        fields: scanFields(),
+      };
+      const map: Record<string, string> = await chrome.runtime.sendMessage({
+        type: 'autofill',
+        context,
+        profile: msg.profile,
+      });
+      await fillForm(map);
+    })();
+  }
+});

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,38 @@
+import { createStore, get, set, del, keys } from 'idb-keyval';
+
+const store = createStore('easydaddy', 'profiles');
+
+export interface Profile {
+  id: string;
+  data: any;
+}
+
+export async function listProfiles(): Promise<Profile[]> {
+  const allKeys = await keys(store);
+  const profiles: Profile[] = [];
+  for (const id of allKeys) {
+    const data = await get(id as string, store);
+    profiles.push({ id: id as string, data });
+  }
+  return profiles;
+}
+
+export async function getProfile(id: string): Promise<any | undefined> {
+  return get(id, store);
+}
+
+export async function saveProfile(id: string, data: any): Promise<void> {
+  await set(id, data, store);
+}
+
+export async function deleteProfile(id: string): Promise<void> {
+  await del(id, store);
+}
+
+export async function getActiveProfileId(): Promise<string | undefined> {
+  return (await get('activeProfileId', store)) as string | undefined;
+}
+
+export async function setActiveProfileId(id: string): Promise<void> {
+  await set('activeProfileId', id, store);
+}

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useState } from 'react';
+import {
+  listProfiles,
+  getProfile,
+  saveProfile,
+  deleteProfile,
+  getActiveProfileId,
+  setActiveProfileId,
+} from '../lib/storage';
+
+const Popup: React.FC = () => {
+  const [profiles, setProfiles] = useState<string[]>([]);
+  const [activeId, setActiveId] = useState<string>('');
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const ps = await listProfiles();
+      setProfiles(ps.map((p) => p.id));
+      const act = (await getActiveProfileId()) || (ps[0]?.id || '');
+      if (act) {
+        setActiveId(act);
+        const data = await getProfile(act);
+        setText(JSON.stringify(data ?? {}, null, 2));
+      }
+    })();
+  }, []);
+
+  const handleSelect = async (id: string) => {
+    setActiveId(id);
+    setActiveProfileId(id);
+    const data = await getProfile(id);
+    setText(JSON.stringify(data ?? {}, null, 2));
+  };
+
+  const handleCreate = async () => {
+    const id = prompt('Profile name?');
+    if (!id) return;
+    await saveProfile(id, {});
+    setProfiles([...profiles, id]);
+    handleSelect(id);
+  };
+
+  const handleDelete = async () => {
+    if (!activeId) return;
+    if (!confirm('Delete profile?')) return;
+    await deleteProfile(activeId);
+    const remaining = profiles.filter((p) => p !== activeId);
+    setProfiles(remaining);
+    const next = remaining[0] || '';
+    handleSelect(next);
+  };
+
+  const handleTextChange = async (val: string) => {
+    setText(val);
+    try {
+      const obj = JSON.parse(val || '{}');
+      if (activeId) await saveProfile(activeId, obj);
+    } catch (e) {
+      // ignore JSON parse errors while editing
+    }
+  };
+
+  const handleFile = async (file: File) => {
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    let raw = '';
+    if (ext === 'pdf') {
+      const pdfjs = await import('pdfjs-dist');
+      const data = await file.arrayBuffer();
+      const doc = await pdfjs.getDocument({ data }).promise;
+      for (let i = 1; i <= doc.numPages; i++) {
+        const page = await doc.getPage(i);
+        const tc = await page.getTextContent();
+        raw += tc.items.map((it: any) => it.str).join(' ') + '\n';
+      }
+    } else {
+      raw = await file.text();
+    }
+    const parsed = await chrome.runtime.sendMessage({
+      type: 'extract_profile',
+      text: raw,
+    });
+    if (parsed && activeId) {
+      try {
+        const current = JSON.parse(text || '{}');
+        const merged = { ...current, ...parsed };
+        setText(JSON.stringify(merged, null, 2));
+        await saveProfile(activeId, merged);
+      } catch (_) {
+        // ignore
+      }
+    }
+  };
+
+  const handleFill = async () => {
+    if (!activeId) return;
+    const profile = await getProfile(activeId);
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (tab?.id)
+      chrome.tabs.sendMessage(tab.id, { type: 'start_fill', profile });
+  };
+
+  return (
+    <div>
+      <select value={activeId} onChange={(e) => handleSelect(e.target.value)}>
+        {profiles.map((p) => (
+          <option key={p}>{p}</option>
+        ))}
+      </select>
+      <button onClick={handleCreate}>New Profile</button>
+      <button onClick={handleDelete}>Delete Profile</button>
+      <textarea
+        value={text}
+        onChange={(e) => handleTextChange(e.target.value)}
+      />
+      <input
+        type="file"
+        accept=".txt,.md,.pdf"
+        onChange={(e) => e.target.files && handleFile(e.target.files[0])}
+      />
+      <button onClick={handleFill}>Fill Out</button>
+    </div>
+  );
+};
+
+export default Popup;

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import Popup from './Popup';
+import './style.css';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(
+    <React.StrictMode>
+      <Popup />
+    </React.StrictMode>
+  );
+}

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -1,0 +1,12 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 10px;
+  width: 300px;
+}
+select, textarea, button {
+  width: 100%;
+  margin-top: 8px;
+}
+textarea {
+  height: 120px;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        popup: resolve(__dirname, 'public/popup.html'),
+        background: resolve(__dirname, 'src/background.ts'),
+        content: resolve(__dirname, 'src/content.ts'),
+      },
+      output: {
+        entryFileNames: '[name].js',
+      },
+    },
+  },
+  publicDir: 'public',
+});


### PR DESCRIPTION
## Summary
- scaffold Chrome extension with manifest, background, content, and popup
- add React popup UI for managing profiles and triggering autofill
- implement storage helper using idb-keyval
- implement OpenAI calls in background script
- scan and fill forms via content script
- configure Vite build

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685808b743b0832ab3a3f59774e05d2b