### PR TITLE
Add instructions field and toggleable profile view

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -313,12 +313,14 @@ Do NOT add any other keys except the selectors listed above. If you do not have 
 You will receive:
 1. PAGE_CONTEXT: contains URL, title, and an array of form fields with descriptions
 2. USER_PROFILE: a structured user profile
+3. INSTRUCTIONS: optional user hints that override the profile for this session
 
-Your task:
-- For each form field, analyze its description and find the most appropriate data in USER_PROFILE
-- Return ONLY a JSON object where keys are selectors from the list above and values are the appropriate data
-- Do NOT add any other keys
-- If there is no suitable data, do not include the selector in the response
+- Your task:
+  - For each form field, analyze its description and find the most appropriate data in USER_PROFILE
+  - Return ONLY a JSON object where keys are selectors from the list above and values are the appropriate data
+  - Do NOT add any other keys
+  - If there is no suitable data, do not include the selector in the response
+  - If INSTRUCTIONS contradict the profile, follow INSTRUCTIONS
 
 Example response:
 {
@@ -332,6 +334,7 @@ PAGE_CONTEXT and USER_PROFILE:
       const promptContext = {
         PAGE_CONTEXT: context,
         USER_PROFILE: profile,
+        INSTRUCTIONS: message.instructions || ''
       };
       try {
         const userContentString = JSON.stringify(promptContext, null, 2);

--- a/src/content.ts
+++ b/src/content.ts
@@ -260,6 +260,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         type: 'autofill',
         context: pageContext,
         profile: message.profile,
+        instructions: message.instructions,
       });
 
       // --- CRITICAL LOGGING ---

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -9,9 +9,9 @@ import {
   initStorage,
 } from '../lib/storage';
 import { Button } from '../components/ui/button';
-import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 import { Card, CardContent } from '../components/ui/card';
+import { Checkbox } from '../components/ui/checkbox';
 
 // Type for profile data
 type ProfileData = Record<string, any>;
@@ -20,6 +20,9 @@ const Popup: React.FC = () => {
   const [profiles, setProfiles] = useState<string[]>([]);
   const [activeProfile, setActiveProfile] = useState<string>('');
   const [profileDataText, setProfileDataText] = useState('');
+  const [showProfileData, setShowProfileData] = useState(false);
+  const [instructions, setInstructions] = useState('');
+  const [sendOnce, setSendOnce] = useState(false);
   const [status, setStatus] = useState('Initializing...');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -169,6 +172,7 @@ const Popup: React.FC = () => {
             type: 'start_fill',
             profileId: activeProfile,
             profile: profileData,
+            instructions,
           },
           (response) => {
             if (chrome.runtime.lastError) {
@@ -184,6 +188,11 @@ const Popup: React.FC = () => {
         );
       }
     });
+
+    if (sendOnce) {
+      setInstructions('');
+      setSendOnce(false);
+    }
   };
 
 
@@ -231,18 +240,33 @@ const Popup: React.FC = () => {
             </section>
 
             <section className="section mb-4">
-              <Label htmlFor="profile-editor" className="sectionTitle block mb-2">
-                Profile Data
-              </Label>
-              <Input
-                asChild
-                id="profile-editor"
-                className="profileEditor w-full mb-2"
-                value={profileDataText}
-                onChange={(e: any) => handleTextChange(e.target.value)}
-                disabled={!activeProfile}
-                placeholder={activeProfile ? "Your profile data will appear here..." : status}
-              />
+              <div className="flex items-center justify-between mb-2">
+                <Label htmlFor="profile-editor" className="sectionTitle">
+                  Profile Data
+                </Label>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setShowProfileData(!showProfileData)}
+                  disabled={!activeProfile}
+                >
+                  {showProfileData ? 'Hide' : 'Show'}
+                </Button>
+              </div>
+              {showProfileData && (
+                <textarea
+                  id="profile-editor"
+                  className="profileEditor w-full mb-2"
+                  value={profileDataText}
+                  onChange={(e: any) => handleTextChange(e.target.value)}
+                  disabled={!activeProfile}
+                  placeholder={
+                    activeProfile
+                      ? 'Your profile data will appear here...'
+                      : status
+                  }
+                />
+              )}
               <input
                 type="file"
                 id="file-upload"
@@ -252,12 +276,33 @@ const Popup: React.FC = () => {
                 accept=".txt,.md,.pdf"
                 disabled={!activeProfile}
               />
-              <Label 
-                htmlFor="file-upload" 
+              <Label
+                htmlFor="file-upload"
                 className={`${!activeProfile ? 'disabled' : ''} fileInputLabel block cursor-pointer`}
               >
                 📄 Upload & Parse Document
               </Label>
+            </section>
+
+            <section className="section mb-4">
+              <Label htmlFor="instructions" className="sectionTitle block mb-2">
+                Additional Instructions
+              </Label>
+              <textarea
+                id="instructions"
+                className="profileEditor w-full mb-2"
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                placeholder="Add any temporary instructions for this fill session..."
+              />
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="send-once"
+                  checked={sendOnce}
+                  onCheckedChange={(v) => setSendOnce(!!v)}
+                />
+                <Label htmlFor="send-once">Send once</Label>
+              </div>
             </section>
 
             {status && (


### PR DESCRIPTION
## Summary
- allow user to toggle visibility of profile JSON in popup
- add one‑time instructions field with checkbox
- send instructions through content/background scripts
- adjust autofill prompt to handle instructions

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc35249d4832ab937250d3c4e56e4